### PR TITLE
FB33305 - fix for apple silicon processors

### DIFF
--- a/wordfence/scanning/filtering.py
+++ b/wordfence/scanning/filtering.py
@@ -1,6 +1,6 @@
 import re
 import os
-from typing import Optional, List, Callable
+from typing import Optional, List, Callable, Pattern, AnyStr
 
 
 class FilterCondition:
@@ -90,10 +90,14 @@ def filter_filename(value: str) -> Callable[[str], bool]:
     return filter
 
 
+class Filter:
+    def __init__(self, pattern: Pattern[AnyStr]):
+        self.pattern = pattern
+
+    def __call__(self, path: str) -> bool:
+        return matches_regex(self.pattern, path)
+
+
 def filter_pattern(regex: str) -> Callable[[str], bool]:
     pattern = re.compile(regex)
-
-    def filter(path: str) -> bool:
-        return matches_regex(pattern, path)
-
-    return filter
+    return Filter(pattern)


### PR DESCRIPTION
On apple silicon processors, the multiprocessing module complains about not being able to pickle filter callables. This does not appear to be an issue on linux.

Replacing these functions with callable class instances, with the class defined at the module level, resolves the issue.

Did not bump the version, under the assumption that will be done soon once additional changes have accumulated.