### PR TITLE
Change to relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wordfence CLI is a multi-process malware scanner written in Python. It's designe
 
 ## Installation
 
-We have a number of installation methods to install Wordfence CLI in our [installation documentation](/wordfence/wordfence-cli/blob/main/docs/Installation.md) which we'd recommend reviewing to get you scanning for malware in as few steps as possible. If you'd like to install Wordfence CLI manually, you can clone the GitHub repo to your local environment:
+We have a number of installation methods to install Wordfence CLI in our [installation documentation](docs/Installation.md) which we'd recommend reviewing to get you scanning for malware in as few steps as possible. If you'd like to install Wordfence CLI manually, you can clone the GitHub repo to your local environment:
 
 	git clone git@github.com:wordfence/wordfence-cli.git
 	cd ./wordfence-cli
@@ -12,7 +12,7 @@ We have a number of installation methods to install Wordfence CLI in our [instal
 	python main.py scan --version
 
 You can additionally build the wheel archive and generate an executable:
-	
+
 	pip install build~=0.10
 	python -m build --wheel
 	pip install dist/wordfence-*.whl
@@ -33,7 +33,7 @@ Visit [https://www.wordfence.com/products/wordfence-cli/](https://www.wordfence.
 
 ## Usage
 
-You can run `wordfence scan --help` for a full list of options that can be passed to Wordfence CLI. Read more about the [configuration options](/wordfence/wordfence-cli/blob/main/docs/Configuration.md) that can be passed to Wordfence CLI.
+You can run `wordfence scan --help` for a full list of options that can be passed to Wordfence CLI. Read more about the [configuration options](docs/Configuration.md) that can be passed to Wordfence CLI.
 
 #### Example
 
@@ -41,12 +41,12 @@ Recursively scanning the `/var/www` directory and writing the results to `/home/
 
 	wordfence scan --output-path /home/username/wordfence-cli.csv /var/www
 
-A [full list of examples](/wordfence/wordfence-cli/blob/main/docs/Examples.md) is included in our documentation.
+A [full list of examples](docs/Examples.md) is included in our documentation.
 
 ## Documentation
 
-The full documentation for Wordfence CLI can be found [here](/wordfence/wordfence-cli/blob/main/docs/) which includes installation instructions, configuration options, detailed examples, and frequently asked questions.
+The full documentation for Wordfence CLI can be found [here](docs/) which includes installation instructions, configuration options, detailed examples, and frequently asked questions.
 
 ## License
 
-Wordfence CLI is open source, licensed under GPLv3. The license can be found [here](/wordfence/wordfence-cli/blob/main/LICENSE).
+Wordfence CLI is open source, licensed under GPLv3. The license can be found [here](LICENSE).


### PR DESCRIPTION
Fix links in README to be relative: [Relative links in markup files](https://github.blog/2013-01-31-relative-links-in-markup-files/)