### PR TITLE
Adjusted time handling and ensured final progress update is always sent at end of scan

### DIFF
--- a/wordfence/scanning/matching.py
+++ b/wordfence/scanning/matching.py
@@ -94,9 +94,9 @@ class RegexMatcherContext(MatcherContext):
         if signature.anchored_to_start and not start:
             return False
         try:
-            signal.alarm(self.matcher.timeout)
+            signal.setitimer(signal.ITIMER_VIRTUAL, self.matcher.timeout)
             match = signature.get_pattern().match(chunk)
-            signal.alarm(0)  # Clear the alarm
+            signal.setitimer(signal.ITIMER_VIRTUAL, 0)  # Clear timeout
             if match is not None:
                 self.matches[signature.signature.identifier] = \
                         match.matched_string
@@ -132,7 +132,7 @@ class RegexMatcherContext(MatcherContext):
             raise TimeoutException()
 
         self._previous_alarm_handler = signal.signal(
-                signal.SIGALRM,
+                signal.SIGVTALRM,
                 handle_timeout
             )
         if self._previous_alarm_handler is None:
@@ -140,8 +140,7 @@ class RegexMatcherContext(MatcherContext):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        signal.signal(signal.SIGALRM, self._previous_alarm_handler)
-        pass
+        signal.signal(signal.SIGVTALRM, self._previous_alarm_handler)
 
 
 class RegexCommonString:

--- a/wordfence/util/timing.py
+++ b/wordfence/util/timing.py
@@ -5,6 +5,10 @@ def unit_seconds(ns: int) -> int:
     return ns / 1000000000
 
 
+def unit_milliseconds(ns: int) -> int:
+    return ns / 1000000
+
+
 class Timer:
 
     def __init__(self, start: bool = True):
@@ -19,6 +23,9 @@ class Timer:
 
     def start(self):
         self.start_time = self._capture_time()
+
+    def reset(self):
+        self.start()
 
     def stop(self):
         self.end_time = self._capture_time()


### PR DESCRIPTION
- A final progress update is now always sent at the end of the scan
- Regex timeouts now use CPU time instead of real time
- Progress updates are now only sent if at least the intended interval has elapsed

Closes #29 