### PR TITLE
With the Voodoo Child release, the syntax to invoke a scan changes

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -79,7 +79,7 @@ To install Wordfence CLI using Docker, you can clone the GitHub repo to your loc
 
 Once the Docker image is built, you can start the docker container with the volumes you wish to scan:
 
-	docker run -v /var/www:/var/www wordfence-cli:latest scan --version
+	docker run -v /var/www:/var/www wordfence-cli:latest malware-scan --version
 
 You should see output similar to this:
 
@@ -94,7 +94,7 @@ To install Wordfence CLI manually, you can clone the GitHub repo to your local e
 	git clone git@github.com:wordfence/wordfence-cli.git
 	cd ./wordfence-cli
 	pip install .
-	python main.py scan --version
+	python main.py malware-scan --version
 
 You can additionally build the wheel archive and generate an executable:
 	


### PR DESCRIPTION
the verb from 'scan' to malware-scan

Installation.md needed to be updated to reflect this.

The Docker instruction:
```
$ docker run -v /var/www:/var/www wordfence-cli:latest scan --version
The "scan" subcommand has been renamed to "malware-scan"
$ docker run -v /var/www:/var/www wordfence-cli:latest malware-scan \
--version
Wordfence CLI 2.0.2 "Voodoo Child"
PCRE Version: 8.39 2016-06-14 - JIT Supported: Yes
```

The native invocation:
```
$ python main.py scan --version
The "scan" subcommand has been renamed to "malware-scan"
$ python main.py malware-scan --version

             ▓▓▓
        ▓▓▓▓▓   ▓▓▓▓▓          _       __               __  ____
  ▓▓▓▓▓▓▓           ▓▓▓▓▓▓▓   | |     / /___  _________/ / / __/__  ____  ________
 ▓▓           ▓           ▓▓  | | /| / / __ \/ ___/ __  /_/ /_/ _ \/ __ \/ ___/ _ \
▓▓     ▓▓    ▓▓▓    ▓▓     ▓▓ | |/ |/ / /_/ / /  / /_/ /_  __/  __/ / / / /__/  __/
▓▓      ▓     ▓     ▓      ▓▓ |__/|__/\____/_/   \____/ /_/  \___/_/ /_/\___/\___/
▓▓    ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓    ▓▓                                       ____ _     ___
▓▓  ▓▓▓ ▓    ▓▓▓    ▓ ▓▓▓  ▓▓                                      / ___| |   |_ _|
▓▓▓▓▓   ▓    ▓▓▓    ▓   ▓▓▓▓▓                                     | |   | |    | |
 ▓▓     ▓   ▓▓ ▓▓   ▓     ▓▓                                      | |___| |___ | |
  ▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓                                        \____|_____|___|

Wordfence CLI 2.0.2 "Voodoo Child"
PCRE Version: 8.40 2017-01-11 - JIT Supported: No
```