### PR TITLE
Fixed issue where PHP parser uses raw string rather than PhpValue when constant is not defined

### DIFF
--- a/wordfence/php/parsing.py
+++ b/wordfence/php/parsing.py
@@ -642,7 +642,8 @@ class PhpConstant(PhpIdentifiedEntity, Evaluable):
         try:
             return state.constants[self.name]
         except KeyError:
-            return self.name  # Constants are treated as strings if undefined
+            # Constants are treated as strings if undefined
+            return PhpValue.for_python_value(self.name)
 
 
 class PhpMagicConstant(PhpEntity, Evaluable):


### PR DESCRIPTION
Resolves #119 