### PR TITLE
Fix for RPM missing from release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
             wordfence_cli_amd64 \
             wordfence_cli_arm64 \
             wordfence_cli_deb \
+            wordfence_cli_rpm_el9 \
             wordfence_cli_python
           do
             pushd "$artifact"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
             wordfence_cli_amd64/*.tar.gz
             wordfence_cli_arm64/*.tar.gz
             wordfence_cli_deb/*.deb
+            wordfence_cli_rpm_el9/*.rpm
             wordfence_cli_python/*.whl
             wordfence_cli_python/*.tar.gz
             wordfence_cli_checksums/checksums.txt


### PR DESCRIPTION
This just adds the new RPM build asset to the steps that create a GitHub release.