### PR TITLE
Update wrong INI section for malware scan in the docs

### DIFF
--- a/docs/malware-scan/Configuration.md
+++ b/docs/malware-scan/Configuration.md
@@ -6,13 +6,13 @@ Configuration can be set through command line arguments, or configured globally 
 
 By default, `wordfence-cli.ini` will reside in `~/.config/wordfence/wordfence-cli.ini`. The INI file is best suited for global configuration options for Wordfence CLI. The license is typically all that's needed to be stored in the INI. You can optionally store the arguments that appear below in the INI if you choose. Keep in mind, that the examples in the documentation here may not work as expected when using scan options stored in the INI.
 
-In order to store malware scan specific configuration in the INI file, you should use `[SCAN]` as the INI section. Here's basic example of an INI file that uses default configuration options along with malware scan options:
+In order to store malware scan specific configuration in the INI file, you should use `[MALWARE_SCAN]` as the INI section. Here's basic example of an INI file that uses default configuration options along with malware scan options:
 
 	[DEFAULT]
 	license = xxx
 	cache-directory = /usr/local/wordfence-cli
 
-	[SCAN]
+	[MALWARE_SCAN]
 	workers = 16
 	exclude-signatures = 99999
 

--- a/docs/malware-scan/Vectorscan.md
+++ b/docs/malware-scan/Vectorscan.md
@@ -26,7 +26,7 @@ By default, CLI will use `libprce` for scanning. To configure CLI to use Vectors
 
 This can also be set in the INI file:
 
-    [MALWARE-SCAN]
+    [MALWARE_SCAN]
     match_engine=vectorscan
 
 ## Installing Vectorscan/Hyperscan


### PR DESCRIPTION
I noticed that the wrong INI section for malware scan is used in the docs.

I tested `[SCAN]`, `[MALWARE-SCAN]`, and `[MALWARE_SCAN]` to be sure and the correct value should be `[MALWARE_SCAN]`