### PR TITLE
Fixed error about mixed bytes and non-bytes in path components when pre-compiling vectorscan DB

### DIFF
--- a/wordfence/cli/malwarescan/malwarescan.py
+++ b/wordfence/cli/malwarescan/malwarescan.py
@@ -267,8 +267,8 @@ class MalwareScanSubcommand(Subcommand):
                 precompiled = compile_database()
                 with tempfile.NamedTemporaryFile(
                             dir=os.path.dirname(database_path),
-                            prefix='compiling.',
-                            suffix='.db',
+                            prefix=b'compiling.',
+                            suffix=b'.db',
                             delete=False
                         ) as file:
                     file.write(pickle.dumps(precompiled))


### PR DESCRIPTION
Resolves #290 