### PR TITLE
Make mysql error message more descriptive

### DIFF
--- a/wordfence/wordpress/database.py
+++ b/wordfence/wordpress/database.py
@@ -50,10 +50,10 @@ class WordpressDatabaseConnection:
             for result in cursor:
                 yield result
             cursor.close()
-        except pymysql.MySQLError:
+        except pymysql.MySQLError as e:
             raise WordpressDatabaseException(
                     self.database,
-                    'Failed to execute query'
+                    f'Failed to execute query: {str(e)}'
                 )
 
     def query_literal(


### PR DESCRIPTION
This makes it so that we get:

```
Error: (<wordfence....>, 'Failed to execute query: (1146, "Table \'mywordpressdb.wp_options\' doesn\'t exist")')
```

instead of:

```
Error: (<wordfence....>, 'Failed to execute query')
```