### PR TITLE
Document db-scan subcommand

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,5 +30,12 @@ Wordfence CLI is a high performance, multi-process, command-line malware scanner
 		- [Scanning a single WordPress installation for vulnerabilities](vuln-scan/Examples.md#scanning-a-single-wordpress-installation-for-vulnerabilities)
 		- [Writing vulnerability scan results to a CSV](vuln-scan/Examples.md#writing-vulnerability-scan-results-to-a-csv)
 		- [Running the vulnerability scan in a cron](vuln-scan/Examples.md#running-the-vulnerability-scan-in-a-cron)
+- **Database Scanning**
+	- [Subcommand Configuration](db-scan/Configuration.md)
+	- [Examples](db-scan/Examples.md)
+		- [Scanning a single WordPress database](db-scan/Examples.md#scanning-a-single-wordpress-database)
+		- [Automatically locating WordPress installations](db-scan/Examples.md#automatically-locating-wordpress-installations)
+		- [Scanning databases listed in a JSON file](db-scan/Examples.md#scanning-databases-listed-in-a-json-file)
+		- [Writing database scan results to a CSV](db-scan/Examples.md#writing-database-scan-results-to-a-csv)
 - [Autocomplete of CLI's subcommands and parameters](Autocomplete.md)
 - [Frequently Asked Questions](FAQs.md)

--- a/docs/db-scan/Configuration.md
+++ b/docs/db-scan/Configuration.md
@@ -1,0 +1,63 @@
+# Database Scan Configuration
+
+Configuration can be set through command line arguments or configured globally in `wordfence-cli.ini`. After installing Wordfence CLI, run `./wordfence configure` to interactively create the global configuration file.
+
+## wordfence-cli.ini
+
+The default configuration path is `~/.config/wordfence/wordfence-cli.ini`. Global options such as the license key or cache directory should live in the `[DEFAULT]` section, while database scan specific settings belong in `[DB_SCAN]`.
+
+	[DEFAULT]
+	license = xxx
+	cache-directory = /usr/local/wordfence-cli
+
+	[DB_SCAN]
+	host = db.example.com
+	user = wordpress
+	database-name = wordpress
+	prompt-for-password = true
+	output-format = human
+
+## Database Scan Command Line Arguments
+
+- `-H`, `--host`: Database hostname. Defaults to `localhost`.
+- `-P`, `--port`: Database port. Defaults to `3306`.
+- `-u`, `--user`: Database user. Defaults to `root`.
+- `--password`: Provide the database password via the command line. This is insecure and should be avoided in favor of prompting or environment variables.
+- `-p`, `--prompt-for-password`: Prompt for the database password on invocation.
+- `--password-env`: Environment variable containing the database password. Defaults to `WFCLI_DB_PASSWORD`.
+- `-x`, `--prefix`: WordPress database prefix. Defaults to `wp_`.
+- `-D`, `--database-name`: Name of the database to scan.
+- `-C`, `--collation`: Collation to use when connecting to MySQL. Defaults to `utf8mb4_unicode_ci`.
+- `--read-stdin`: Force reading database configuration paths from stdin. When stdin is not a terminal, the command automatically reads paths without specifying this flag.
+- `-s`, `--path-separator`: Separator used when reading paths from stdin. Defaults to the null byte (`AA==` in base64 form).
+- `--require-database`: Error if no databases are provided. This is automatically enforced when running interactively.
+- `-S`, `--locate-sites`: Scan one or more filesystem paths for `wp-config.php` files and extract database credentials automatically.
+- `--allow-nested`: Permit nested WordPress installations when locating sites. Enabled by default.
+- `--allow-io-errors`: Continue locating sites when IO errors occur. Enabled by default.
+- `--use-remote-rules`: Pull the latest database scanning rules from the Wordfence API. Enabled by default.
+- `-R`, `--rules-file`: Path to a JSON rules file to merge into the database rule set. May be provided multiple times.
+- `-e`, `--exclude-rules`: Rule IDs to ignore when scanning. Accepts comma-delimited lists and repeated flags.
+- `-i`, `--include-rules`: Rule IDs to include when scanning. Accepts comma-delimited lists and repeated flags.
+- `--output`: Write results to stdout (default when `--output-path` is not set).
+- `--output-path`: Destination file for scan results.
+- `--output-columns`: Comma-delimited list of columns to include in the output. Available columns: `table`, `rule_id`, `rule_description`, `row`. Column customization is supported for `csv`, `tsv`, `null-delimited`, and `line-delimited` formats.
+- `-m`, `--output-format`: Output format for results. Supported values: `human` (default), `csv`, `tsv`, `null-delimited`, `line-delimited`.
+- `--output-headers`: Include column headers in formats that support them (`csv`, `tsv`, `null-delimited`, `line-delimited`).
+
+When `--locate-sites` is not used, each trailing argument should be a JSON file containing a list of database configurations in the following shape:
+
+	[
+	  {
+	    "name": "wordpress",
+	    "user": "wordpress",
+	    "password": "example",
+	    "host": "db.example.com",
+	    "port": 3306,
+	    "collation": "utf8mb4_unicode_ci",
+	    "prefix": "wp_"
+	  }
+	]
+
+Entries may omit `port`, `collation`, or `prefix`; defaults are applied automatically.
+
+When databases are discovered through `--locate-sites` or provided via JSON files, connection details from those sources override the command-line defaults for each database.

--- a/docs/db-scan/Examples.md
+++ b/docs/db-scan/Examples.md
@@ -1,0 +1,25 @@
+# Examples
+
+## Scanning a single WordPress database
+
+Scan a WordPress database using explicit connection settings and prompt for the password at runtime.
+
+	wordfence db-scan -H db.example.com -P 3306 -u wordpress -D wordpress --prompt-for-password
+
+## Automatically locating WordPress installations
+
+Search the supplied directories for `wp-config.php`, extract the database credentials, and scan each discovered site.
+
+	wordfence db-scan -S /var/www/wordpress /srv/wordpress
+
+## Scanning databases listed in a JSON file
+
+Provide a JSON file that lists one or more database configurations. Each entry must include `name`, `user`, `password`, and `host`, with optional `port`, `collation`, and `prefix` values. Multiple JSON files can be supplied.
+
+	wordfence db-scan /etc/wordfence/databases.json
+
+## Writing database scan results to a CSV
+
+Output scan results to a CSV file with headers and explicitly selected columns.
+
+	wordfence db-scan -S /var/www/wordpress --output-format csv --output-columns table,rule_description,row --output-headers --output-path /home/username/db-scan-results.csv

--- a/docs/db-scan/README.md
+++ b/docs/db-scan/README.md
@@ -1,0 +1,8 @@
+## Database Scanning Contents
+
+- [Subcommand Configuration](Configuration.md)
+- [Examples](Examples.md)
+	- [Scanning a single WordPress database](Examples.md#scanning-a-single-wordpress-database)
+	- [Automatically locating WordPress installations](Examples.md#automatically-locating-wordpress-installations)
+	- [Scanning databases listed in a JSON file](Examples.md#scanning-databases-listed-in-a-json-file)
+	- [Writing database scan results to a CSV](Examples.md#writing-database-scan-results-to-a-csv)


### PR DESCRIPTION
Fixes #328.

## Summary
- add a database scanning section to the docs with configuration and examples
- document CLI arguments, defaults, and JSON database configuration format
- link the new db-scan docs from the main documentation index

## Testing
- Tests not run (docs only)
