### PR TITLE
Remove unused screen handler global

### DIFF
--- a/wordfence/cli/malwarescan/malwarescan.py
+++ b/wordfence/cli/malwarescan/malwarescan.py
@@ -27,7 +27,6 @@ screen_handler: Optional[logging.Handler] = None
 
 
 def revert_progress_changes() -> None:
-    global screen_handler
     if screen_handler:
         log.removeHandler(screen_handler)
     restore_initial_handler()


### PR DESCRIPTION
## Summary
- drop the unnecessary global statement in `revert_progress_changes`
- rely on the module-level `screen_handler` assignment already in place

## Testing
- `./venv/bin/python -m flake8 --exclude venv --require-plugins pycodestyle,flake8-bugbear`
