### PR TITLE
Handle UTF-8 output for reports

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -2,7 +2,7 @@ name: "Unit Testing"
 on: [push]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get update && sudo apt-get install -y python3-pymysql python3-requests

--- a/wordfence/cli/reporting.py
+++ b/wordfence/cli/reporting.py
@@ -614,7 +614,11 @@ class ReportManager:
 
     def open_output_file(self) -> Optional[IO]:
         mode = 'w+' if self.will_email() else 'w'
-        return open(resolve_path(self.config.output_path), mode) \
+        return open(
+                resolve_path(self.config.output_path),
+                mode,
+                encoding='utf-8'
+            ) \
             if self.config.output_path is not None \
             else nullcontext()
 

--- a/wordfence/cli/test_reporting.py
+++ b/wordfence/cli/test_reporting.py
@@ -1,0 +1,41 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from wordfence.cli.reporting import ReportManager
+from wordfence.cli.dbscan.reporting import (
+        DatabaseScanReportFormat,
+        DatabaseScanReportColumn
+    )
+
+
+class ReportManagerEncodingTest(unittest.TestCase):
+
+    def test_open_output_file_uses_utf8_encoding(self):
+        config = SimpleNamespace(
+                output=None,
+                output_path='/tmp/out.csv',
+                email=None
+            )
+        context = SimpleNamespace(config=config)
+        manager = ReportManager(
+                DatabaseScanReportFormat,
+                DatabaseScanReportColumn,
+                context,
+                read_stdin=None,
+                input_delimiter='\0'
+            )
+
+        patcher = mock.patch(
+                'wordfence.cli.reporting.open',
+                mock.mock_open()
+            )
+        with patcher as mock_open:
+            manager.open_output_file()
+
+        _, kwargs = mock_open.call_args
+        self.assertEqual('utf-8', kwargs.get('encoding'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #327.

## Summary
- open report output files with an explicit UTF-8 encoding to support non-ASCII characters
- add a regression test that verifies the UTF-8 encoding flag is passed to the file handle

## Testing
- ./venv/bin/python -m unittest discover -s wordfence -t .
- ./venv/bin/python -m flake8 --exclude venv --require-plugins pycodestyle,flake8-bugbear
