### PR TITLE
CI: use ubuntu-latest for unit workflow

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -2,7 +2,7 @@ name: "Unit Testing"
 on: [push]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get update && sudo apt-get install -y python3-pymysql python3-requests


### PR DESCRIPTION
## Summary
- bump the unit testing workflow to run on ubuntu-latest so jobs hit GitHub's largest runner pool

## Testing
- ./venv/bin/python -m unittest discover -s wordfence -t .
- ./venv/bin/python -m flake8 --exclude venv --require-plugins pycodestyle,flake8-bugbear
