### PR TITLE
Respect --no-images when include-all-files is used

### DIFF
--- a/wordfence/cli/malwarescan/malwarescan.py
+++ b/wordfence/cli/malwarescan/malwarescan.py
@@ -137,6 +137,8 @@ class MalwareScanSubcommand(Subcommand):
         has_include_overrides = False
         if self.config.include_all_files:
             filter.add(filtering.filter_any)
+            if not self.config.images:
+                filter.add(filtering.filter_images, False)
         if self.config.include_files is not None:
             has_include_overrides = True
             for name in self.config.include_files:

--- a/wordfence/scanning/test_filtering.py
+++ b/wordfence/scanning/test_filtering.py
@@ -1,0 +1,22 @@
+import unittest
+
+from wordfence.scanning import filtering
+
+
+class FileFilterTests(unittest.TestCase):
+
+    def test_filter_any_allows_non_images(self):
+        file_filter = filtering.FileFilter()
+        file_filter.add(filtering.filter_any)
+        file_filter.add(filtering.filter_images, False)
+        self.assertTrue(file_filter.filter(b'/tmp/allowed.php'))
+
+    def test_filter_any_deny_images(self):
+        file_filter = filtering.FileFilter()
+        file_filter.add(filtering.filter_any)
+        file_filter.add(filtering.filter_images, False)
+        self.assertFalse(file_filter.filter(b'/tmp/image.jpg'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deny rule so image extensions stay excluded when `-a/--include-all-files` is used unless `--images` is set
- cover the FileFilter allow/deny interaction with a unit test

## Testing
- python -m unittest wordfence.scanning.test_filtering
