### PR TITLE
Break circular CLI imports to enable CLI tests

### DIFF
--- a/wordfence/cli/config/__init__.py
+++ b/wordfence/cli/config/__init__.py
@@ -1,17 +1,20 @@
-import os
+from __future__ import annotations
 
-from typing import List, Dict, Tuple
+import os
+from typing import TYPE_CHECKING, List, Dict, Tuple
 from dataclasses import dataclass
 
-from ..helper import Helper
 from .cli_parser import CliCanonicalValueExtractor, get_cli_values
 from .config_items import ConfigItemDefinition, \
     CanonicalValueExtractorInterface, not_set_token
 from .ini_parser import load_ini, get_ini_value_extractor, \
         get_default_ini_value_extractor
-from ..subcommands import SubcommandDefinition
 from .base_config_definitions import config_map as base_config_map
 from .config import Config
+
+if TYPE_CHECKING:
+    from ..helper import Helper
+    from ..subcommands import SubcommandDefinition
 
 
 value_extractors: List = []
@@ -80,7 +83,7 @@ def create_config_object(
 
 def _get_renamed_subcommand(
             subcommand: str,
-            definitions: Dict[str, SubcommandDefinition]
+            definitions: Dict[str, 'SubcommandDefinition']
         ) -> str:
     for definition in definitions.values():
         if subcommand in definition.previous_names:
@@ -90,7 +93,7 @@ def _get_renamed_subcommand(
         )
 
 
-def resolve_config_map(subcommand_definition: SubcommandDefinition):
+def resolve_config_map(subcommand_definition: 'SubcommandDefinition'):
     return {
             **base_config_map,
             **subcommand_definition.get_config_map()
@@ -103,11 +106,11 @@ class GlobalConfig:
 
 
 def load_config(
-            subcommand_definitions: Dict[str, SubcommandDefinition],
-            helper: Helper,
+            subcommand_definitions: Dict[str, 'SubcommandDefinition'],
+            helper: 'Helper',
             subcommand: str = None,
             global_config: GlobalConfig = None
-        ) -> Tuple[Config, SubcommandDefinition]:
+        ) -> Tuple[Config, 'SubcommandDefinition']:
     cli_values, trailing_arguments, parser = get_cli_values(
             subcommand_definitions,
             helper

--- a/wordfence/cli/config/cli_parser.py
+++ b/wordfence/cli/config/cli_parser.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import argparse
 import json
 import os
 from argparse import ArgumentParser, Namespace
-from typing import Set, List, Dict, Any, Tuple
+from typing import TYPE_CHECKING, Set, List, Dict, Any, Tuple
 
 from wordfence.logging import log
-from ..helper import Helper
 from .config_items import ConfigItemDefinition, \
     CanonicalValueExtractorInterface, Context, ArgumentType, \
     not_set_token
 from .base_config_definitions \
         import config_map as base_config_map
-from ..subcommands import SubcommandDefinition
+
+if TYPE_CHECKING:
+    from ..helper import Helper
+    from ..subcommands import SubcommandDefinition
 
 NAME = "Wordfence CLI"
 DESCRIPTION = ("Multifunction commandline tool for Wordfence - "
@@ -147,8 +151,8 @@ def add_definitions_to_parser(
 
 
 def get_cli_values(
-            subcommand_definitions: Dict[str, SubcommandDefinition],
-            helper: Helper
+            subcommand_definitions: Dict[str, 'SubcommandDefinition'],
+            helper: 'Helper'
         ) -> Tuple[Namespace, List[str], ArgumentParser]:
     parser = ArgumentParser(
             prog=COMMAND,

--- a/wordfence/cli/config/ini_parser.py
+++ b/wordfence/cli/config/ini_parser.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import errno
 import json
 import os
+
 from argparse import Namespace
 from configparser import ConfigParser, NoSectionError
-from typing import List, Set, Any, Callable, Optional
+from typing import TYPE_CHECKING, List, Set, Any, Callable, Optional
 
 from wordfence.logging import log
 from .config_items import Context, ConfigItemDefinition, \
@@ -11,7 +14,9 @@ from .config_items import Context, ConfigItemDefinition, \
     ReferenceToken, merge_config_maps
 from .defaults import INI_DEFAULT_PATH
 from .base_config_definitions import config_map as base_config_map
-from ..subcommands import SubcommandDefinition
+
+if TYPE_CHECKING:
+    from ..subcommands import SubcommandDefinition
 
 
 valid_contexts: Set[Context] = {Context.ALL, Context.CONFIG}
@@ -114,7 +119,7 @@ class IniCanonicalValueExtractor(CanonicalValueExtractorInterface):
 
 
 def get_ini_value_extractor(
-            subcommand_definition: SubcommandDefinition
+            subcommand_definition: 'SubcommandDefinition'
         ) -> IniCanonicalValueExtractor:
     return IniCanonicalValueExtractor(
             subcommand_definition.config_section,
@@ -137,7 +142,7 @@ def get_ini_path(cli_values: Namespace) -> str:
 
 def load_ini(
             cli_values,
-            subcommand_definition: Optional[SubcommandDefinition]
+            subcommand_definition: Optional['SubcommandDefinition']
         ) -> (ConfigParser, Optional[str]):
     config = ConfigParser()
     try:

--- a/wordfence/cli/test_malwarescan_filter.py
+++ b/wordfence/cli/test_malwarescan_filter.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+
+
+class MalwareScanFilterTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if 'pymysql' not in sys.modules:
+            sys.modules['pymysql'] = types.ModuleType('pymysql')
+        from wordfence.cli.malwarescan.malwarescan import MalwareScanSubcommand
+        from wordfence.scanning.filtering import FileFilter
+
+        cls._subcommand_cls = MalwareScanSubcommand
+        cls._file_filter_cls = FileFilter
+
+    def _build_filter(self, **overrides):
+        defaults = {
+            'include_all_files': False,
+            'include_files': None,
+            'include_files_pattern': None,
+            'exclude_files': None,
+            'exclude_files_pattern': None,
+            'images': False,
+        }
+        defaults.update(overrides)
+        subcommand = object.__new__(self._subcommand_cls)
+        subcommand.config = SimpleNamespace(**defaults)
+        return subcommand._initialize_file_filter()
+
+    def test_initialize_file_filter_with_include_all_files(self):
+        filter_instance = self._build_filter(include_all_files=True)
+        self.assertIsInstance(filter_instance, self._file_filter_cls)
+        self.assertTrue(filter_instance.filter(b'/tmp/allowed.php'))
+        self.assertTrue(filter_instance.filter(b'/tmp/image.jpg'))
+
+    def test_initialize_file_filter_images_flag(self):
+        filter_instance = self._build_filter(
+            include_all_files=True,
+            images=True,
+        )
+        self.assertTrue(filter_instance.filter(b'/tmp/image.jpg'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- defer CLI helper and subcommand imports to type-check blocks so config modules can initialize without recursion
- adjust type annotations to use forward references
- add a CLI-level malware scan filter test to catch future cycles

Fixes #339.

## Testing
- python -m unittest wordfence.cli.test_malwarescan_filter
