### PR TITLE
Handle directive-heavy wp-config parsing

### DIFF
--- a/wordfence/php/parsing.py
+++ b/wordfence/php/parsing.py
@@ -516,6 +516,11 @@ _register_unary_operator(
         lambda value: PhpValue(value.type, not value.value)
     )
 
+_register_unary_operator(
+        b'@',
+        lambda value: value
+    )
+
 
 class PhpBinaryOperator(PhpOperator):
 

--- a/wordfence/wordpress/__init__.py
+++ b/wordfence/wordpress/__init__.py
@@ -1,3 +1,8 @@
-from . import site
-
 __all__ = ['site']
+
+
+def __getattr__(name):
+    if name == 'site':
+        from . import site as module
+        return module
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/wordfence/wordpress/config.py
+++ b/wordfence/wordpress/config.py
@@ -1,0 +1,188 @@
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+from ..php.parsing import (
+        PhpBinaryOperator,
+        PhpCallableInvocation,
+        PhpConditional,
+        PhpConstant,
+        PhpExpression,
+        PhpInstruction,
+        PhpInstructionGroup,
+        PhpLiteral,
+        PhpMagicConstant,
+        PhpVariableReference,
+        parse_php_file
+    )
+
+
+@dataclass
+class WordpressConfigState:
+    constants: Dict[bytes, bytes] = field(default_factory=dict)
+    variables: Dict[bytes, bytes] = field(default_factory=dict)
+
+    def get_constant_value(
+                self,
+                name: bytes,
+                default_to_name: bool = True
+            ) -> Optional[bytes]:
+        try:
+            return self.constants[name]
+        except KeyError:
+            if default_to_name:
+                return name
+            return None
+
+    def get_variable_value(self, name: bytes) -> Optional[bytes]:
+        return self.variables.get(name)
+
+
+class WordpressConfigParser:
+
+    def __init__(self, path: bytes):
+        self.path = os.fsencode(path)
+        self.state = WordpressConfigState()
+
+    def parse(self) -> WordpressConfigState:
+        context = parse_php_file(self.path)
+        self._process_instructions(context.instructions)
+        return self.state
+
+    def _process_instructions(
+                self,
+                instructions: Iterable[PhpInstruction]
+            ) -> None:
+        for instruction in instructions:
+            self._process_instruction(instruction)
+
+    def _process_instruction(self, instruction: PhpInstruction) -> None:
+        if isinstance(instruction, PhpExpression):
+            self._process_expression(instruction)
+        elif isinstance(instruction, PhpInstructionGroup):
+            self._process_instructions(instruction.instructions)
+        elif isinstance(instruction, PhpConditional):
+            for condition in instruction.conditions:
+                instructions = condition.instruction_group.instructions
+                self._process_instructions(instructions)
+
+    def _process_expression(self, expression: PhpExpression) -> None:
+        components = expression.components
+        if len(components) == 0:
+            return
+        first = components[0]
+        if isinstance(first, PhpCallableInvocation):
+            self._process_callable(first)
+        elif isinstance(first, PhpVariableReference):
+            self._process_assignment(components)
+
+    def _process_callable(self, invocation: PhpCallableInvocation) -> None:
+        callable_reference = invocation.callable
+        name = getattr(callable_reference, 'name', None)
+        if name is None:
+            return
+        normalized = name.lower()
+        has_arguments = len(invocation.arguments) >= 2
+        if normalized == b'define' and has_arguments:
+            constant_name = self._resolve_expression(invocation.arguments[0])
+            constant_value = self._resolve_expression(invocation.arguments[1])
+            if constant_name is not None and constant_value is not None:
+                self.state.constants[constant_name] = constant_value
+
+    def _process_assignment(self, components) -> None:
+        if len(components) < 3:
+            return
+        variable = components[0]
+        operator = components[1]
+        if not isinstance(operator, PhpBinaryOperator) \
+                or operator.operator != b'=':
+            return
+        value = self._resolve_components(components[2:])
+        if value is not None:
+            self.state.variables[variable.name] = value
+
+    def _resolve_expression(
+                self,
+                expression: PhpExpression
+            ) -> Optional[bytes]:
+        return self._resolve_components(expression.components)
+
+    def _resolve_components(self, components) -> Optional[bytes]:
+        value: Optional[bytes] = None
+        pending_operator: Optional[bytes] = None
+        for component in components:
+            if isinstance(component, PhpBinaryOperator):
+                pending_operator = component.operator
+                continue
+            resolved = self._resolve_component(component)
+            if resolved is None:
+                return None
+            if value is None:
+                value = resolved
+            else:
+                if pending_operator == b'.':
+                    value = value + resolved
+                elif pending_operator in {b'.=', b'='}:
+                    value = resolved
+                else:
+                    return None
+            pending_operator = None
+        return value
+
+    def _resolve_component(self, component) -> Optional[bytes]:
+        if isinstance(component, PhpLiteral):
+            return self._convert_literal(component.value)
+        if isinstance(component, PhpExpression):
+            return self._resolve_expression(component)
+        if isinstance(component, PhpCallableInvocation):
+            return self._resolve_callable_component(component)
+        if isinstance(component, PhpVariableReference):
+            return self.state.variables.get(component.name)
+        if isinstance(component, PhpConstant):
+            return self.state.constants.get(component.name)
+        if isinstance(component, PhpMagicConstant):
+            return self._resolve_magic_constant(component)
+        return None
+
+    def _resolve_callable_component(
+                self,
+                invocation: PhpCallableInvocation
+            ) -> Optional[bytes]:
+        callable_reference = invocation.callable
+        name = getattr(callable_reference, 'name', None)
+        if name is None:
+            return None
+        normalized = name.lower()
+        if normalized == b'constant' and len(invocation.arguments) >= 1:
+            constant_name = self._resolve_expression(
+                    invocation.arguments[0]
+                )
+            if constant_name is not None:
+                return self.state.constants.get(constant_name)
+        return None
+
+    def _resolve_magic_constant(
+                self,
+                constant: PhpMagicConstant
+            ) -> Optional[bytes]:
+        if hasattr(constant, 'token_type'):
+            token = constant.token_type
+            if token.name == 'DIR':
+                return os.path.dirname(self.path)
+            if token.name == 'FILE':
+                return self.path
+        return None
+
+    def _convert_literal(self, value) -> Optional[bytes]:
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, str):
+            return value.encode('latin1')
+        if isinstance(value, int):
+            return str(value).encode('latin1')
+        return None
+
+
+def parse_wordpress_config(path: bytes) -> WordpressConfigState:
+    parser = WordpressConfigParser(path)
+    return parser.parse()

--- a/wordfence/wordpress/test_config.py
+++ b/wordfence/wordpress/test_config.py
@@ -1,0 +1,251 @@
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+if 'pymysql' not in sys.modules:
+    class _PyMySqlError(Exception):
+        pass
+
+    def _connect(*args, **kwargs):
+        raise _PyMySqlError()
+
+    sys.modules['pymysql'] = SimpleNamespace(
+            MySQLError=_PyMySqlError,
+            connect=_connect,
+            cursors=SimpleNamespace(DictCursor=object)
+        )
+
+from .config import parse_wordpress_config
+from .site import WordpressSite
+
+
+class WordpressConfigParserTest(unittest.TestCase):
+
+    def _write_config(self, directory: str, content: str) -> str:
+        path = os.path.join(directory, 'wp-config.php')
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(content)
+        return path
+
+    def test_extracts_database_constants_with_directives(self) -> None:
+        content = (
+                "<?php\n"
+                "ini_set( 'max_execution_time', 300 );\n"
+                "@ini_set( 'log_errors', 'Off' );\n"
+                "set_time_limit( 300 );\n"
+                "define( 'DB_NAME', 'wordpress' );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', 'localhost' );\n"
+                "define( 'DB_COLLATE', '' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(os.fsencode(path))
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_NAME',
+                        default_to_name=False
+                    ),
+                    b'wordpress'
+                )
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_USER',
+                        default_to_name=False
+                    ),
+                    b'wp_user'
+                )
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_PASSWORD',
+                        default_to_name=False
+                    ),
+                    b'secret'
+                )
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_HOST',
+                        default_to_name=False
+                    ),
+                    b'localhost'
+                )
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_COLLATE',
+                        default_to_name=False
+                    ),
+                    b''
+                )
+            self.assertEqual(
+                    state.get_variable_value(b'table_prefix'),
+                    b'wp_'
+                )
+
+    def test_handles_concatenated_prefix(self) -> None:
+        content = (
+                "<?php\n"
+                "$table_prefix = 'wp_' . 'blog';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(os.fsencode(path))
+            self.assertEqual(
+                    state.get_variable_value(b'table_prefix'),
+                    b'wp_blog'
+                )
+
+    def test_extracts_constants_inside_conditional_block(self) -> None:
+        content = (
+                "<?php\n"
+                "if ( ! defined( 'DB_NAME' ) ) {\n"
+                "    define( 'DB_NAME', 'conditional' );\n"
+                "}\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', 'localhost' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(path.encode())
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_NAME',
+                        default_to_name=False
+                    ),
+                    b'conditional'
+                )
+
+    def test_resolves_constant_function_call(self) -> None:
+        content = (
+                "<?php\n"
+                "define( 'PRIMARY_DB', 'primary' );\n"
+                "define( 'DB_NAME', constant( 'PRIMARY_DB' ) );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', 'localhost' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(path.encode())
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_NAME',
+                        default_to_name=False
+                    ),
+                    b'primary'
+                )
+
+    def test_ignores_unknown_functions(self) -> None:
+        content = (
+                "<?php\n"
+                "custom_setup();\n"
+                "define( 'DB_NAME', 'wordpress' );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', 'localhost' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(path.encode())
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_NAME',
+                        default_to_name=False
+                    ),
+                    b'wordpress'
+                )
+
+    def test_unresolved_values_are_skipped(self) -> None:
+        content = (
+                "<?php\n"
+                "define( 'DB_NAME', getenv( 'WP_DB_NAME' ) );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._write_config(directory, content)
+            state = parse_wordpress_config(os.fsencode(path))
+            self.assertIsNone(
+                    state.get_constant_value(
+                        b'DB_NAME',
+                        default_to_name=False
+                    )
+                )
+            self.assertEqual(
+                    state.get_constant_value(
+                        b'DB_USER',
+                        default_to_name=False
+                    ),
+                    b'wp_user'
+                )
+
+
+class WordpressSiteDatabaseTest(unittest.TestCase):
+
+    def _create_minimal_site(self, directory: str, config: str) -> str:
+        os.makedirs(directory, exist_ok=True)
+        for name in ('wp-admin', 'wp-includes'):
+            os.makedirs(os.path.join(directory, name), exist_ok=True)
+        for name in ('wp-load.php', 'wp-blog-header.php'):
+            path = os.path.join(directory, name)
+            with open(path, 'w', encoding='utf-8') as handle:
+                handle.write("<?php\n")
+        includes_version = os.path.join(
+                directory,
+                'wp-includes',
+                'version.php'
+            )
+        with open(includes_version, 'w', encoding='utf-8') as handle:
+            handle.write("<?php $wp_version = '6.4.0';")
+        config_path = os.path.join(directory, 'wp-config.php')
+        with open(config_path, 'w', encoding='utf-8') as handle:
+            handle.write(config)
+        return directory
+
+    def test_get_database_uses_new_parser(self) -> None:
+        config = (
+                "<?php\n"
+                "ini_set( 'max_execution_time', 300 );\n"
+                "define( 'DB_NAME', 'wordpress' );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', 'localhost' );\n"
+                "define( 'DB_COLLATE', '' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            site_path = self._create_minimal_site(directory, config)
+            site = WordpressSite(os.fsencode(site_path))
+            database = site.get_database()
+            self.assertEqual(database.name, 'wordpress')
+            self.assertEqual(database.server.user, 'wp_user')
+            self.assertEqual(database.server.host, 'localhost')
+            self.assertEqual(database.server.password, 'secret')
+            self.assertEqual(database.prefix, 'wp_')
+
+    def test_get_database_parses_port_from_host(self) -> None:
+        config = (
+                "<?php\n"
+                "define( 'DB_NAME', 'wordpress' );\n"
+                "define( 'DB_USER', 'wp_user' );\n"
+                "define( 'DB_PASSWORD', 'secret' );\n"
+                "define( 'DB_HOST', '127.0.0.1:3307' );\n"
+                "define( 'DB_COLLATE', '' );\n"
+                "$table_prefix = 'wp_';\n"
+            )
+        with tempfile.TemporaryDirectory() as directory:
+            site_path = self._create_minimal_site(directory, config)
+            site = WordpressSite(os.fsencode(site_path))
+            database = site.get_database()
+            self.assertEqual(database.server.host, '127.0.0.1')
+            self.assertEqual(database.server.port, 3307)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a targeted WordPress config parser that extracts DB credentials without executing helper directives
- wire the new parser into WordpressSite and tolerate @-prefixed functions when reading wp-config
- cover conditional defines, constant() indirection, host:port parsing, and other wp-config variants with focused unit tests

## Testing
- venv/bin/python -m unittest discover -s wordfence -t .