### PR TITLE
Fixed SoftwareType caching

### DIFF
--- a/wordfence/cli/cli.py
+++ b/wordfence/cli/cli.py
@@ -92,7 +92,7 @@ class WordfenceCli:
         log.setLevel(logging.INFO)
 
     def _get_cacheable_types(self) -> Set[str]:
-        cacheable_types = {'builtins.getattr'}
+        cacheable_types = set()
         cacheable_types.update(licensing.CACHEABLE_TYPES)
         cacheable_types.update(terms_management.CACHEABLE_TYPES)
         for definition in self.subcommand_definitions.values():

--- a/wordfence/intel/vulnerabilities.py
+++ b/wordfence/intel/vulnerabilities.py
@@ -41,6 +41,9 @@ class SoftwareType(str, Enum):
     PLUGIN = 'plugin'
     THEME = 'theme'
 
+    def __reduce_ex__(self, proto):
+        return (SoftwareType, (self.value,))
+
 
 @dataclass
 class ScannableSoftware:


### PR DESCRIPTION
In some versions of Python, serializing an enum using pickle uses the `getattr` builtin which is not currently included in the allowlist. Adding that to the allowlist is not secure as it would allow a malicious cache file to call getattr on anything. Instead, I've overridden the reducer for `SoftwareType` so that it invokes the enums constructor instead (which is already on the allowlist).

Resolves #323 