### PR TITLE
New column `database` for `db-scan` command

### DIFF
--- a/docs/db-scan/Configuration.md
+++ b/docs/db-scan/Configuration.md
@@ -25,7 +25,7 @@ Database scanning can be configured using either command line arguments, the [IN
 - `-i`, `--include-rules`: Rule IDs to include when scanning. Accepts comma-delimited lists and repeated flags.
 - `--output`: Write results to stdout (default when `--output-path` is not set).
 - `--output-path`: Destination file for scan results.
-- `--output-columns`: Comma-delimited list of columns to include in the output. Available columns: `table`, `rule_id`, `rule_description`, `row`. Column customization is supported for `csv`, `tsv`, `null-delimited`, and `line-delimited` formats.
+- `--output-columns`: Comma-delimited list of columns to include in the output. Available columns: `database`, `table`, `rule_id`, `rule_description`, `row`. Column customization is supported for `csv`, `tsv`, `null-delimited`, and `line-delimited` formats.
 - `-m`, `--output-format`: Output format for results. Supported values: `human` (default), `csv`, `tsv`, `null-delimited`, `line-delimited`.
 - `--output-headers`: Include column headers in formats that support them (`csv`, `tsv`, `null-delimited`, `line-delimited`).
 
@@ -42,7 +42,7 @@ path_separator = <separator>
 # Controls whether or not output is written to stdout
 output = [on|off]
 output_path = <path to which to write results>
-# Comma-delimited list of columns to include in output (`table`, `rule_id`, `rule_description`, `row`)
+# Comma-delimited list of columns to include in output (`database`, `table`, `rule_id`, `rule_description`, `row`)
 output_columns = <columns>
 output_format = [human|csv|tsv|null-delimited|line-delimited]
 # Whether to include headers in output

--- a/wordfence/cli/dbscan/reporting.py
+++ b/wordfence/cli/dbscan/reporting.py
@@ -14,6 +14,7 @@ from ..email import Mailer
 
 
 class DatabaseScanReportColumn(ReportColumnEnum):
+    DATABASE = 'database', lambda record: record.result.database
     TABLE = 'table', lambda record: record.result.table
     RULE_ID = 'rule_id', lambda record: record.result.rule.identifier
     RULE_DESCRIPTION = 'rule_description', \
@@ -28,7 +29,7 @@ class HumanReadableWriter(BaseHumanReadableWriter):
         return (
                 escape(Color.YELLOW)
                 + 'Suspicious database record found in table '
-                f'"{result.table}" matching rule "{result.rule.description}"'
+                f'"{result.database}.{result.table}" matching rule "{result.rule.description}"'
                 ': ' + safe_json_encode(record.result.row) + RESET
             )
 

--- a/wordfence/databasescanning/scanner.py
+++ b/wordfence/databasescanning/scanner.py
@@ -10,10 +10,12 @@ class DatabaseScanResult:
 
     def __init__(
                 self,
+                database: WordpressDatabase,
                 rule: DatabaseRule,
                 table: str,
                 row: dict
             ):
+        self.database = database
         self.rule = rule
         self.table = table
         self.row = row
@@ -70,6 +72,7 @@ class DatabaseScanner:
             rule = self.rule_set.get_rule(result['rule_id'])
             del result['rule_id']
             yield DatabaseScanResult(
+                    database=connection.database.name,
                     rule=rule,
                     table=prefixed_table,
                     row=result


### PR DESCRIPTION
The new column `database` allows for easy identification of the concerned database. This is especially useful when scanning multiple databases at once. Without this it would be very difficult to find which site the result is for.