### PR TITLE
Db scan socket support

### DIFF
--- a/docs/db-scan/Configuration.md
+++ b/docs/db-scan/Configuration.md
@@ -6,6 +6,7 @@ Database scanning can be configured using either command line arguments, the [IN
 
 - `-H`, `--host`: Database hostname. Defaults to `localhost`.
 - `-P`, `--port`: Database port. Defaults to `3306`.
+- `--socket`: Path to a unix socket to use when connecting to the database. Takes precedence over the host and port options and also applies to sites located using `--locate-sites`.
 - `-u`, `--user`: Database user. Defaults to `root`.
 - `--password`: Provide the database password via the command line. This is insecure and should be avoided in favor of prompting or environment variables.
 - `-p`, `--prompt-for-password`: Prompt for the database password on invocation.

--- a/wordfence/cli/dbscan/dbscan.py
+++ b/wordfence/cli/dbscan/dbscan.py
@@ -58,7 +58,8 @@ class DbScanSubcommand(Subcommand):
                 host=self.config.host,
                 port=self.config.port,
                 user=self.config.user,
-                password=self._resolve_password()
+                password=self._resolve_password(),
+                socket=self.config.socket
             )
         return WordpressDatabase(
                 name=name,
@@ -97,6 +98,8 @@ class DbScanSubcommand(Subcommand):
                     )
                 try:
                     database = site.get_database()
+                    if self.config.socket is not None:
+                        database.server.socket = self.config.socket
                     yield database
                 except WordpressException:
                     if self.config.allow_io_errors:
@@ -115,9 +118,10 @@ class DbScanSubcommand(Subcommand):
                         'password': str,
                         'host': str,
                         'port': OptionalValueValidator(int),
+                        'socket': OptionalValueValidator(str),
                         'collation': OptionalValueValidator(str),
                         'prefix': OptionalValueValidator(str)
-                    }, optional_keys={'port', 'collation'})
+                    }, optional_keys={'port', 'socket', 'collation'})
             )
 
     def _parse_configured_databases(
@@ -135,6 +139,10 @@ class DbScanSubcommand(Subcommand):
                     except KeyError:
                         port = DEFAULT_PORT
                     try:
+                        socket = config['socket']
+                    except KeyError:
+                        socket = None
+                    try:
                         collation = config['collation']
                     except KeyError:
                         collation = DEFAULT_COLLATION
@@ -148,7 +156,8 @@ class DbScanSubcommand(Subcommand):
                                     host=config['host'],
                                     port=port,
                                     user=config['user'],
-                                    password=config['password']
+                                    password=config['password'],
+                                    socket=socket
                                 ),
                             prefix=prefix,
                             collation=collation

--- a/wordfence/cli/dbscan/definition.py
+++ b/wordfence/cli/dbscan/definition.py
@@ -26,6 +26,19 @@ config_definitions: ConfigDefinitions = {
         },
         "category": "Database Connectivity"
     },
+    "socket": {
+        "description": "Path to a unix socket to use when connecting to "
+                       "the database. Takes precedence over the host and "
+                       "port options and also applies to sites located "
+                       "using the locate-sites option.",
+        "context": "CLI",
+        "argument_type": "OPTION",
+        "default": None,
+        "meta": {
+            "accepts_file": True
+        },
+        "category": "Database Connectivity"
+    },
     "user": {
         "short_name": "u",
         "description": "The database user",

--- a/wordfence/wordpress/database.py
+++ b/wordfence/wordpress/database.py
@@ -19,6 +19,7 @@ class WordpressDatabaseConnection:
             self.connection = pymysql.connect(
                     host=database.server.host,
                     port=database.server.port,
+                    unix_socket=database.server.socket,
                     user=database.server.user,
                     password=database.server.password,
                     database=database.name
@@ -94,12 +95,14 @@ class WordpressDatabaseServer:
                 host: str = DEFAULT_HOST,
                 port: int = DEFAULT_PORT,
                 user: str = DEFAULT_USER,
-                password: Optional[str] = None
+                password: Optional[str] = None,
+                socket: Optional[str] = None
             ):
         self.host = host
         self.port = port
         self.user = user
         self.password = password
+        self.socket = socket
 
 
 class WordpressDatabase:
@@ -115,12 +118,16 @@ class WordpressDatabase:
         self.server = server
         self.prefix = prefix
         self.collation = collation
-        self.debug_string = self._build_debug_string()
 
     def connect(self) -> WordpressDatabaseConnection:
         return WordpressDatabaseConnection(self)
 
-    def _build_debug_string(self) -> str:
+    @property
+    def debug_string(self) -> str:
+        if self.server.socket is not None:
+            return (
+                    f'{self.server.user}@{self.server.socket}/{self.name}'
+                )
         return (
                 f'{self.server.user}@{self.server.host}:'
                 f'{self.server.port}/{self.name}'

--- a/wordfence/wordpress/site.py
+++ b/wordfence/wordpress/site.py
@@ -505,10 +505,14 @@ class WordpressSite(PathResolver):
         config = self._extract_database_config()
         host_components = config['host'].split(':', 1)
         host = host_components[0]
-        try:
-            port = int(host_components[1])
-        except IndexError:
-            port = DEFAULT_PORT
+        port = DEFAULT_PORT
+        socket = None
+        if len(host_components) > 1:
+            # WordPress supports both "host:port" and "host:/path/to/socket"
+            try:
+                port = int(host_components[1])
+            except ValueError:
+                socket = host_components[1]
         try:
             collation = config['collation']
         except KeyError:
@@ -517,7 +521,8 @@ class WordpressSite(PathResolver):
                 host=host,
                 port=port,
                 user=config['user'],
-                password=config['password']
+                password=config['password'],
+                socket=socket
             )
         return WordpressDatabase(
                 name=config['name'],


### PR DESCRIPTION
Fixes #377 

This PR adds support for connecting to MySQL through a unix socket in the db-scan command:

- Added unix socket support to WordPress database connections - WordpressDatabaseServer accepts an optional socket which is passed to PyMySQL's unix_socket parameter. When set, it takes precedence over host and port. The database debug string was converted to a property so it always reflects the actual connection method in log output.
- Fixed parsing of DB_HOST values containing a unix socket path - WordPress supports the host:/path/to/socket syntax in DB_HOST; the previous logic parsed anything after a colon as a port number and raised an unhandled ValueError during --locate-sites scans.
- Added --socket option to the db-scan command - applies to databases specified via CLI options, entries in JSON database configurations (new optional "socket" key), and sites located with --locate-sites, where it overrides the host and port extracted from wp-config.php while keeping the site's credentials.

Example - scanning all sites on a server where MariaDB listens only on a socket:

`wordfence db-scan -S /var/www --socket /run/mysqld/mysqld.sock`

Backward compatibility: the option defaults to None, in which case PyMySQL ignores it and behavior is unchanged. All existing uses of the debug string are reads, so the property conversion is transparent.